### PR TITLE
Fix color page breadcrumbs

### DIFF
--- a/src/pages/Colors/ColorGroup.jsx
+++ b/src/pages/Colors/ColorGroup.jsx
@@ -23,10 +23,10 @@ const ColorGroup = ({ groupTitle = "Fresh Whites & Creams" }) => {
       {/* Breadcrumb */}
       <div className="text-sm px-6 pt-6 max-w-7xl mx-auto">
         <div className="flex items-center space-x-2 text-gray-600">
-          <span
-            className="underline cursor-pointer hover:text-black"
-            onClick={() => navigate("/paint-colors")}
-          >
+            <span
+              className="underline cursor-pointer hover:text-black"
+              onClick={() => navigate("/colors")}
+            >
             Paint Colors
           </span>
           <span>›</span>

--- a/src/pages/Colors/IndividualColorPage.jsx
+++ b/src/pages/Colors/IndividualColorPage.jsx
@@ -38,7 +38,7 @@ const ColorPage = ({ colorName }) => {
                     <span>›</span>
                     <span
                     className="text-[#1a1a1a] underline cursor-pointer hover:text-black"
-                    onClick={() => navigate(`/paint-colors#${currentColor.groupTitle.replace(/\s+/g, "-").toLowerCase()}`)}
+                    onClick={() => navigate(`/colors#${currentColor.groupTitle.replace(/\s+/g, "-").toLowerCase()}`)}
                     >
                     {currentColor.groupTitle}
                     </span>


### PR DESCRIPTION
## Summary
- fix breadcrumbs on color group and color detail pages so they link to `/colors`

## Testing
- `npm run lint` *(fails: 59 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c4f3cc3508330be9643fee33843be